### PR TITLE
商品一覧、詳細表示、編集、削除機能

### DIFF
--- a/app/assets/stylesheets/item/show.css
+++ b/app/assets/stylesheets/item/show.css
@@ -1,0 +1,3 @@
+.item-controll a{
+  color: black;
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new]
+  before_action :authenticate_user!, only: [:new, :edit]
 
   def index
     @items = Item.all
@@ -23,22 +23,26 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
-  # def edit
-  #   @item = Item.find(params[:id])
-  #   item_attributes = @item.attributes
-  #   @item_form = ItemForm.new(item_attributes)
-  # end
+  def edit
+    @item = Item.find(params[:id])
+    item_attributes = @item.attributes
+    @item_form = ItemForm.new(item_attributes)
+    @item_form.tag_name = @item.tags.first&.tag_name
+  end
 
-  # def update
-  #   @item = Item.find(params[:id])
-  #   @item_form = ItemForm.new(item_form_params)
-  #   if @item_form.valid?
-  #     @item_form.update(item_form_params, @item)
-  #     redirect_to root_path
-  #   else
-  #     render :edit
-  #   end
-  # end
+  def update
+    @item = Item.find(params[:id])
+    @item_form = ItemForm.new(item_form_params)
+
+    @item_form.images ||= @item.images.blobs
+    
+    if @item_form.valid?
+      @item_form.update(item_form_params, @item)
+      redirect_to root_path
+    else
+      render :edit
+    end
+  end
 
   private
   

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -44,6 +44,15 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    item = Item.find(params[:id])
+    if current_user.id == item.user_id
+      item.item_tags.destroy_all
+      item.destroy
+      redirect_to root_path
+    end
+  end
+
   private
   
   def item_form_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   # def edit
   #   @item = Item.find(params[:id])
   #   item_attributes = @item.attributes

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
+  before_action :move_to_index, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.all
@@ -57,6 +58,13 @@ class ItemsController < ApplicationController
   
   def item_form_params
     params.require(:item_form).permit(:product, :content, :category_id, :postage_id, :delivery_day_id, :price, :tag_name, {images: []}).merge(user_id: current_user.id)
+  end
+
+  def move_to_index
+    @item = Item.find(params[:id])
+    if current_user.id != @item.user_id
+      redirect_to root_path
+    end
   end
 
   

--- a/app/javascript/delete.js
+++ b/app/javascript/delete.js
@@ -1,0 +1,7 @@
+window.addEventListener('load', function(){
+  const delete_btn = document.getElementById("delete-btn");
+
+  delete_btn.addEventListener(`click`, function(){
+    alert("商品情報を削除しますか？")
+  })
+})

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,7 +8,7 @@ require("@rails/ujs").start()
 require("@rails/activestorage").start()
 require("channels")
 require("../preview")
-
+require("../delete")
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,8 +11,8 @@ class Item < ApplicationRecord
   has_many :item_tags
   has_many :tags, through: :item_tags
 
-  # extend ActiveHash::Associations::ActiveRecordExtensions
-  # belongs_to :category
-  # belongs_to :postage
-  # belongs_to :delivery_day
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :category
+  belongs_to :postage
+  belongs_to :delivery_day
 end

--- a/app/models/item_form.rb
+++ b/app/models/item_form.rb
@@ -2,7 +2,8 @@ class ItemForm
   include ActiveModel::Model
   #ItemFormクラスのオブジェクトがItemモデルの属性を扱えるようにする
   attr_accessor :product, :content, :category_id, :postage_id,:delivery_day_id, :price, :user_id, :images,
-                :tag_name
+                :tag_name,
+                :id, :created_at, :updated_at
 
   with_options presence: true do
     validates :product
@@ -25,8 +26,17 @@ class ItemForm
   end
 
   # controllerで呼び出したupdateメソッドから引数を受け取る
-  # def update(params, item)
-  #   item.update(params)
-  # end
+  def update(params, item)
+    # 一度タグの紐づけを消す
+    item.item_tags.destroy_all
+    # params内のタグ情報削除
+    tag_name = params.delete(:tag_name)
+    
+    tag = Tag.where(tag_name: tag_name).first_or_initialize if tag_name.present?
+
+    tag.save if tag_name.present?
+    item.update(params)
+    ItemTag.create(item_id: item.id, tag_id: tag.id) if tag_name.present?
+  end
 
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -4,7 +4,7 @@
 
   <div class="items-sell-main">
     <h2 class="items-sell-title">作品の情報を入力</h2>
-    <%= form_with model: @item_form, id: 'new_item', local: true do |f| %>
+    <%= form_with model: @item_form, url: item_path(@item.id), method: :patch, id: 'new_item', local: true do |f| %>
 
     <%= render 'shared/error_messages', model: f.object %>
     
@@ -114,8 +114,8 @@
     
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "出品する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%= f.submit "変更する" ,class:"sell-btn" %>
+      <%=link_to 'もどる', "/items/#{@item.id}", class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -23,7 +23,9 @@
       <% @items.each do |item| %>
         <div class="posted-content">
           <%# 代表一枚 %>
-          <%= image_tag item.images[0], class: "main-image" %><br>
+          <%= link_to "/items/#{item.id}" do %>
+            <%= image_tag item.images[0], class: "main-image" %><br>
+          <% end %>
             <%# その他 %>
             <div class="posted-content-others">
               <% item.images[1..-1].each do |image| %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -23,9 +23,7 @@
       <% @items.each do |item| %>
         <div class="posted-content">
           <%# 代表一枚 %>
-          <%= link_to "/items/#{item.id}" do %>
-            <%= image_tag item.images[0], class: "main-image" %><br>
-          <% end %>
+            <%= link_to image_tag(item.images[0], class: "main-image"), "/items/#{item.id}" %><br>
             <%# その他 %>
             <div class="posted-content-others">
               <% item.images[1..-1].each do |image| %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -4,7 +4,7 @@
 
   <div class="items-sell-main">
     <h2 class="items-sell-title">作品の情報を入力</h2>
-    <%= form_with model: @item_form, id: 'new_item', local: true do |f| %>
+    <%= form_with model: @item_form, url: items_path, method: :post, id: 'new_item', local: true do |f| %>
 
     <%= render 'shared/error_messages', model: f.object %>
     

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -34,4 +34,5 @@
   </div>
 
   <%= link_to '編集する', edit_item_path(@item.id)%>
+
 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,19 @@
+<h3>詳細ページ</h3>
+<div class="posted-content">
+  <%# 代表一枚 %>
+  <%= image_tag @item.images[0], class: "main-image" %><br>
+    <%# その他 %>
+    <div class="posted-content-others">
+      <% @item.images[1..-1].each do |image| %>
+        <div class="other-images">
+          <%= image_tag image, class: "other-image" %>
+        </div>
+      <% end %>
+    </div>
+  <%= @item.content %><br>
+  <div>
+    <div><%= @item.tags.first&.tag_name %></div>
+  </div>
+  </table>
+  <%# <%= link_to '編集', edit_item_path(@item.id)%> %>
+</div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -10,10 +10,28 @@
         </div>
       <% end %>
     </div>
-  <%= @item.content %><br>
+
+  <%# 商品説明 %>
+  <div class="content-product">
+    <%= @item.content %>
+  </div>
+
+  <%# 商品価格、送料 %>
+  <div class="content-product">
+    <span><%= @item.price %>円<br>
+    <%= @item.postage.name %></span>
+  </div>
+
+  <%# 配達予想、カテゴリー %>
+  <div class="content-product">
+    <%= @item.delivery_day.name %>
+    <%= @item.category.name %>
+  </div>
+  
+  <%# タグ %>
   <div>
     <div><%= @item.tags.first&.tag_name %></div>
   </div>
-  </table>
-  <%# <%= link_to '編集', edit_item_path(@item.id)%> %>
+
+  <%= link_to '編集する', edit_item_path(@item.id)%>
 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/second-header"%>
+
 <h3>詳細ページ</h3>
 <div class="posted-content">
   <%# 代表一枚 %>
@@ -33,6 +35,13 @@
     <div><%= @item.tags.first&.tag_name %></div>
   </div>
 
-  <%= link_to '編集する', edit_item_path(@item.id)%>
+  <% if user_signed_in?%>
+    <% if current_user.id == @item.user_id %>
+      <%= link_to '編集する', edit_item_path(@item.id), method: :get, class: "item-edit" %>
+      <%= link_to '削除する', item_path(@item.id), method: :delete, class:"item-destroy" %>
+    <% else %>
+      <%= link_to '購入する', "#" %>
+    <% end %>
+  <% end %>
 
 </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -35,13 +35,14 @@
     <div><%= @item.tags.first&.tag_name %></div>
   </div>
 
-  <% if user_signed_in?%>
-    <% if current_user.id == @item.user_id %>
-      <%= link_to '編集する', edit_item_path(@item.id), method: :get, class: "item-edit" %>
-      <%= link_to '削除する', item_path(@item.id), method: :delete, class:"item-destroy" %>
-    <% else %>
-      <%= link_to '購入する', "#" %>
+  <div class="item-controll">
+    <%= link_to '購入する', "#", class: "item-order" %>
+    <% if user_signed_in?%>
+      <% if current_user.id == @item.user_id %>
+        <%= link_to '編集する', edit_item_path(@item.id), method: :get, class: "item-edit" %>
+        <%= link_to '削除する', item_path(@item.id), method: :delete, class:"item-destroy", id: "delete-btn" %>
+      <% end %>
     <% end %>
-  <% end %>
+  </div>
 
 </div>


### PR DESCRIPTION
# What
　出品者が投稿した商品の一覧、詳細が見られる。
　出品者は詳細ページから情報の編集、削除が行える。
# Why
　トップページから出品商品の画像を見て、詳細ページに飛ばせるため。次の購入機能を実装するため。
　情報の編集、削除を行えるようにし、出品者が出品商品を管理できるようにするため。